### PR TITLE
Add PC/SC support on Linux

### DIFF
--- a/src/pcsc.c
+++ b/src/pcsc.c
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#if __APPLE__
+#if __APPLE__ || __UNIX__
 #include <PCSC/wintypes.h>
 #include <PCSC/winscard.h>
 #else
 #include <winscard.h>
-#endif /* __APPLE__ */
+#endif /* __APPLE__ || __UNIX__ */
 
 #include <errno.h>
 


### PR DESCRIPTION
This should allow more NFC hardware to be used on Linux and other Unix-likes. I don't have supported NFC hardware to test, but it works with a Cryptnox FIDO Card in a contact reader.